### PR TITLE
Use git to install aurutils and remove colons in package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN sed -i 's,#DisableSandbox,DisableSandbox,' /etc/pacman.conf
 # Note: update (-u) so that the newly installed tools use up-to-date packages.
 #       For example, gcc (in base-devel) fails if it uses an old glibc (from
 #       base image).
-RUN pacman -Syu --noconfirm base-devel
+RUN pacman -Syu --noconfirm base-devel git
 
 # Patch makepkg to allow running as root; see
 # https://www.reddit.com/r/archlinux/comments/6qu4jt/how_to_run_makepkg_in_docker_container_yes_as_root/
@@ -46,8 +46,7 @@ USER builder
 RUN \
     gpg --import /tmp/gpg_key_6BC26A17B9B7018A.gpg.asc && \
     cd /tmp/ && \
-    curl --output aurutils.tar.gz https://aur.archlinux.org/cgit/aur.git/snapshot/aurutils.tar.gz && \
-    tar xf aurutils.tar.gz && \
+    git clone --depth 1 https://aur.archlinux.org/aurutils.git && \
     cd aurutils && \
     makepkg --syncdeps --noconfirm && \
     sudo pacman -U --noconfirm aurutils-*.pkg.tar.zst && \

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # build-aur-packages
 
-Github Action that builds AUR packages and provides the built packages as
-package repository in the github workspace.
+Github Action that builds AUR packages and/or custom PKGBUILD directories and
+provides the built packages as package repository in the github workspace.
 From there, other actions can use the package repository to install packages or
 upload the repository to some share or ...
 
@@ -42,6 +42,40 @@ If a dependency from AUR is missing, you can pass this to
 `missing_aur_dependencies`.
 
 The resulting repository information will be copied to the github workspace.
+
+## Custom PKGBUILDs
+
+In addition to, packages from AUR, you can build custom
+PKGBUILDs that are already present in the github workspace. Pass a
+space-separated list of directories with the `custom_pkgbuild_directories`
+input. Each directory must contain a `PKGBUILD`.
+The `packages` input can be omitted when `custom_pkgbuild_directories` is set.
+
+```yaml
+jobs:
+  build_repository:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Packages
+      uses: kopp/build-aur-packages@v1
+      with:
+        custom_pkgbuild_directories: >
+          pkgbuilds/my-library
+          pkgbuilds/my-tool
+```
+
+Relative paths are resolved from `$GITHUB_WORKSPACE`. The paths are split on
+spaces, so avoid spaces in custom PKGBUILD directory names.
+
+When custom PKGBUILD directories are set, `missing_aur_dependencies` are built
+first, then custom PKGBUILD directories are built in the order listed, and then
+packages from `packages` are built. This lets custom packages satisfy
+dependencies of later AUR packages. If a custom PKGBUILD itself needs an AUR
+package, list that package in `missing_aur_dependencies`. If custom PKGBUILDs
+depend on each other, list their directories in dependency order. If a custom
+PKGBUILD produces a package with the same name as an entry in `packages`, that
+entry is skipped from the later AUR build.
 
 
 # Maintenance
@@ -99,9 +133,9 @@ After this is done, the docker image is ready.
 When the docker container is executed, it runs [`update_repository.sh`](./update_repository.sh).
 This will pick up all inputs from the github action (which are passed as environmen variables)
 `INPUT_<name>`.
-It will then install dependencies via `pacman` and use `aur sync` to fetch and build aur
-packages.
-They are added to the `aurci2` local database.
+It will then install dependencies via `pacman`, use `aur sync` to fetch and build aur
+packages, and use `makepkg` to build any custom PKGBUILD directories.
+The resulting packages are added to the `aurci2` local database.
 
 Finally, all files (in particular including the database files) are copied to the
 `$GITHUB_WORKSPACE`, where other actions can pick them up, e.g. as in

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,7 @@
 name: "Build AUR package repository"
 description: >
-    Build a given list of AUR packages and store them in a repository.
+    Build a given list of AUR packages and/or custom PKGBUILD directories and
+    store them in a repository.
 branding:
   icon: package
   color: blue
@@ -9,7 +10,15 @@ inputs:
     description: >
         A string with a space separated list of aur packages that should
         be built and included in the repository.
-    required: true
+    required: false
+    default: ""
+  custom_pkgbuild_directories:
+    description: >
+        A string with a space separated list of directories containing custom
+        PKGBUILD files that should be built and included in the repository.
+        Relative paths are resolved from the GitHub workspace.
+    required: false
+    default: ""
   missing_pacman_dependencies:
     description: >
         A string with a space separated list of dependencies that are not

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -27,6 +27,17 @@ sudo --user builder \
     --noconfirm --noview \
     --database aurci2 --root /local_repository \
     $packages_with_aur_dependencies
+    
+cd /local_repository
+shopt -s nullglob
+for file in *:*pkg.tar*; do
+    echo "Detected colon in filename: $file"
+    new_name="${file//:/.}"
+    echo "Renaming to: $new_name"
+    mv "$file" "$new_name"
+    sudo --user builder repo-add aurci2.db.tar.gz "$new_name"
+done
+shopt -u nullglob
 
 # Move the local repository to the workspace.
 if [ -n "$GITHUB_WORKSPACE" ]

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -5,11 +5,175 @@ set -e
 # Print each line before executing.
 set -x
 
-# Get list of all packages with dependencies to install.
-packages_with_aur_dependencies="$(aur depends --pkgname $INPUT_PACKAGES $INPUT_MISSING_AUR_DEPENDENCIES)"
+INPUT_PACKAGES="${INPUT_PACKAGES:-}"
+INPUT_CUSTOM_PKGBUILD_DIRECTORIES="${INPUT_CUSTOM_PKGBUILD_DIRECTORIES:-}"
+INPUT_MISSING_PACMAN_DEPENDENCIES="${INPUT_MISSING_PACMAN_DEPENDENCIES:-}"
+INPUT_MISSING_AUR_DEPENDENCIES="${INPUT_MISSING_AUR_DEPENDENCIES:-}"
+CUSTOM_BUILT_PACKAGE_NAMES=""
+
+if [ -z "$INPUT_PACKAGES" ] && [ -z "$INPUT_CUSTOM_PKGBUILD_DIRECTORIES" ]
+then
+    echo "Error: Set at least one of packages or custom_pkgbuild_directories."
+    exit 1
+fi
+
+resolve_pkgbuild_directory() {
+    local input_directory="$1"
+
+    if [[ "$input_directory" = /* ]]
+    then
+        printf '%s\n' "$input_directory"
+    elif [ -n "$GITHUB_WORKSPACE" ]
+    then
+        printf '%s\n' "$GITHUB_WORKSPACE/$input_directory"
+    else
+        printf '%s\n' "$input_directory"
+    fi
+}
+
+add_package_to_repository() {
+    local package_file="$1"
+    local package_destination="/local_repository/$(basename -- "$package_file")"
+
+    cp -- "$package_file" "$package_destination" || return 1
+    chown builder:alpm "$package_destination" || return 1
+    sudo --user builder repo-add /local_repository/aurci2.db.tar.gz "$package_destination" || return 1
+
+    local package_info
+    package_info="$(pacman -Qp "$package_destination")" || return 1
+    CUSTOM_BUILT_PACKAGE_NAMES="$CUSTOM_BUILT_PACKAGE_NAMES ${package_info%% *}"
+}
+
+build_custom_pkgbuild_directory() {
+    local input_directory="$1"
+    local source_directory
+    source_directory="$(resolve_pkgbuild_directory "$input_directory")"
+
+    if [ ! -d "$source_directory" ]
+    then
+        echo "Error: Custom PKGBUILD directory does not exist: $source_directory"
+        return 1
+    fi
+
+    if [ ! -f "$source_directory/PKGBUILD" ]
+    then
+        echo "Error: Custom PKGBUILD directory has no PKGBUILD: $source_directory"
+        return 1
+    fi
+
+    local build_directory
+    build_directory="$(mktemp -d /tmp/custom-pkgbuild.XXXXXX)" || return 1
+
+    cp -a "$source_directory"/. "$build_directory"/ || return 1
+    chown -R builder:alpm "$build_directory" || return 1
+
+    sudo --user builder bash -c \
+        'cd "$1" && makepkg --syncdeps --noconfirm --clean' \
+        _ "$build_directory" || return 1
+
+    local package_list
+    package_list="$(sudo --user builder bash -c \
+        'cd "$1" && makepkg --packagelist' \
+        _ "$build_directory")" || return 1
+
+    if [ -z "$package_list" ]
+    then
+        echo "Error: Custom PKGBUILD did not produce any package files: $source_directory"
+        return 1
+    fi
+
+    local package_file
+    local package_path
+    while IFS= read -r package_file
+    do
+        [ -n "$package_file" ] || continue
+        if [ -f "$package_file" ]
+        then
+            package_path="$package_file"
+        elif [ -f "$build_directory/$package_file" ]
+        then
+            package_path="$build_directory/$package_file"
+        else
+            echo "Error: Expected package file does not exist: $package_file"
+            return 1
+        fi
+
+        add_package_to_repository "$package_path" || return 1
+    done <<< "$package_list"
+
+    # Refresh the local repository database so later custom PKGBUILDs can depend
+    # on packages built earlier in this run.
+    pacman -Sy || return 1
+}
+
+build_aur_packages() {
+    local requested_packages="$1"
+    local description="$2"
+
+    if [ -z "$requested_packages" ]
+    then
+        echo "No $description."
+        return 0
+    fi
+
+    local packages_with_dependencies
+    packages_with_dependencies="$(aur depends --pkgname $requested_packages)"
+
+    echo "$description: $requested_packages"
+    echo "$description (including dependencies): $packages_with_dependencies"
+
+    # Add the packages to the local repository one by one.
+    # We iterate through the list to ensure that if one package fails,
+    # we can continue with the others.
+    for pkg in $packages_with_dependencies; do
+        echo "Building package: $pkg"
+        if ! sudo --user builder \
+            aur sync \
+            --noconfirm --noview \
+            --clean \
+            --database aurci2 --root /local_repository \
+            "$pkg"; then
+            echo "Error: Failed to build package $pkg. Skipping..."
+        fi
+    done
+
+    pacman -Sy
+}
+
+is_custom_built_package() {
+    local package_name="$1"
+    local custom_package_name
+
+    for custom_package_name in $CUSTOM_BUILT_PACKAGE_NAMES; do
+        if [ "$package_name" = "$custom_package_name" ]
+        then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+filter_custom_packages_from_aur_requests() {
+    local requested_packages="$1"
+    local filtered_packages=""
+    local requested_package
+
+    for requested_package in $requested_packages; do
+        if is_custom_built_package "$requested_package"
+        then
+            echo "Skipping AUR package $requested_package because a custom PKGBUILD built it." >&2
+        else
+            filtered_packages="$filtered_packages $requested_package"
+        fi
+    done
+
+    printf '%s\n' "$filtered_packages"
+}
+
 echo "AUR Packages requested to install: $INPUT_PACKAGES"
 echo "AUR Packages to fix missing dependencies: $INPUT_MISSING_AUR_DEPENDENCIES"
-echo "AUR Packages to install (including dependencies): $packages_with_aur_dependencies"
+echo "Custom PKGBUILD directories requested: $INPUT_CUSTOM_PKGBUILD_DIRECTORIES"
 
 # Sync repositories.
 pacman -Sy
@@ -21,20 +185,22 @@ then
     pacman --noconfirm -S $INPUT_MISSING_PACMAN_DEPENDENCIES
 fi
 
-# Add the packages to the local repository one by one.
-# We iterate through the list to ensure that if one package fails, 
-# we can continue with the others.
-for pkg in $packages_with_aur_dependencies; do
-    echo "Building package: $pkg"
-    if ! sudo --user builder \
-        aur sync \
-        --noconfirm --noview \
-        --clean \
-        --database aurci2 --root /local_repository \
-        "$pkg"; then
-        echo "Error: Failed to build package $pkg. Skipping..."
-    fi
-done
+if [ -n "$INPUT_CUSTOM_PKGBUILD_DIRECTORIES" ]
+then
+    build_aur_packages "$INPUT_MISSING_AUR_DEPENDENCIES" "AUR Packages to fix missing dependencies"
+
+    for pkgbuild_directory in $INPUT_CUSTOM_PKGBUILD_DIRECTORIES; do
+        echo "Building custom PKGBUILD directory: $pkgbuild_directory"
+        if ! build_custom_pkgbuild_directory "$pkgbuild_directory"; then
+            echo "Error: Failed to build custom PKGBUILD directory $pkgbuild_directory. Skipping..."
+        fi
+    done
+
+    aur_packages_after_custom="$(filter_custom_packages_from_aur_requests "$INPUT_PACKAGES")"
+    build_aur_packages "$aur_packages_after_custom" "AUR Packages requested to install"
+else
+    build_aur_packages "$INPUT_PACKAGES $INPUT_MISSING_AUR_DEPENDENCIES" "AUR Packages to install"
+fi
 
 cd /local_repository
 shopt -s nullglob

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -21,14 +21,21 @@ then
     pacman --noconfirm -S $INPUT_MISSING_PACMAN_DEPENDENCIES
 fi
 
-# Add the packages to the local repository.
-sudo --user builder \
-    aur sync \
-    --noconfirm --noview \
-    --clean \
-    --database aurci2 --root /local_repository \
-    $packages_with_aur_dependencies
-    
+# Add the packages to the local repository one by one.
+# We iterate through the list to ensure that if one package fails, 
+# we can continue with the others.
+for pkg in $packages_with_aur_dependencies; do
+    echo "Building package: $pkg"
+    if ! sudo --user builder \
+        aur sync \
+        --noconfirm --noview \
+        --clean \
+        --database aurci2 --root /local_repository \
+        "$pkg"; then
+        echo "Error: Failed to build package $pkg. Skipping..."
+    fi
+done
+
 cd /local_repository
 shopt -s nullglob
 for file in *:*pkg.tar*; do


### PR DESCRIPTION
As shown in #6 , `curl`ing a package directly will be blocked. This PR uses `git clone` to install `aurutils`.

Moreover, github release change colons in package name to dots for Windows compatibility. But the data in `aurci2.db` is recorded as the one with colons. That would result in a url request error. 3475a30d7ea65cb3937037ed8373df0ed5fa37f1 fixes the problem by changing the colons in the `aurci2.db` to the version adhering to the Github release standard. This would not influence the version control, because the real **package version** information is stored in `.PKGINFO`, independent of the **file name**.

This PR has been tested in [this repo](https://github.com/NeumoNeumo/aurci2).